### PR TITLE
Fix issue where multiple grep matches cause SNMP getnext failure

### DIFF
--- a/usr/sbin/snmpd-smartctl-connector
+++ b/usr/sbin/snmpd-smartctl-connector
@@ -82,7 +82,7 @@ function send_device_info
 	DEVFNAME="${DEVFNAME}_info"
 
 	# Find the entry in above file
-	VALUE=$(grep "${1}" < "${DEVFNAME}")
+	VALUE=$(grep -m 1 "${1}" < "${DEVFNAME}")
 	VALUE=${VALUE#${1}}
 	VALUE="${VALUE#"${VALUE%%[![:space:]]*}"}"
 	VALUE="${VALUE%"${VALUE##*[![:space:]]}"}"
@@ -142,7 +142,7 @@ function send_device_attr
 
 	# Find the entry in above file
     # shellcheck disable=SC2207
-	if VALUES=($(grep "${1}" < "${DEVFNAME}")); then
+	if VALUES=($(grep -m 1 -E ${1} < "${DEVFNAME}")); then
 		if [[ "${2}" == "R" ]]; then
 			if is_positive_integer "${VALUES[9]}"; then
 				send_gauge "${3}" "${VALUES[9]}"
@@ -160,31 +160,6 @@ function send_device_attr
 		fi
 	else
 		send_gauge "${3}" -1
-	fi
-}
-
-# Function to send device temperature - called: send_device_temp OID DEVICE
-#
-#	@in_param	$1 - The OID to send before this data
-#	@in_param	$2 - The index value
-#
-function send_device_temp
-{
-	local DEVFNAME VALUES
-
-	# Make the device info filename
-	get_device_file_basepath "${2}" DEVFNAME
-	DEVFNAME="${DEVFNAME}_attr"
-
-	# Find the entry in above file
-    # shellcheck disable=SC2207
-	VALUES=($(grep "Temperature_Celsius" < "${DEVFNAME}")) || \
-	    VALUES=($(grep "Airflow_Temperature" < "${DEVFNAME}"))
-
-	if is_positive_integer "${VALUES[9]}"; then
-		send_gauge "${1}" "${VALUES[9]}"
-	else
-		send_gauge "${1}" -1
 	fi
 }
 
@@ -258,16 +233,16 @@ RTABLE[2]="#ETABLE"
 		FTABLE[6]="send_device_info 'User Capacity:'" 				# It is for the device user capacity.
 		FTABLE[7]="send_device_info 'ATA Version is:'"				# It is for the device ATA version.
 		FTABLE[8]="send_device_hlth"								# It is for the overall SMART health state.
-		FTABLE[9]="send_device_temp" 								# It is for the device temperature.
+		FTABLE[9]="send_device_attr 'Temperature_Cel|Airflow_Temp' R" 		# It is for the device temperature.
 		FTABLE[10]="send_device_attr 'Reallocated_Sector_Ct' R" 	# It is for the Reallocated Sector Count of this device.
-		FTABLE[11]="send_device_attr 'Current_Pending_Sector' R"	# It is for the Current Pending Sector count of this device.
-		FTABLE[12]="send_device_attr 'Offline_Uncorrectable' R" 	# It is for the Off-line Uncorrectable count of this device.
-		FTABLE[13]="send_device_attr 'UDMA_CRC_Error_Count' R" 		# It is for the UDMA CRC Error count of this device.
+		FTABLE[11]="send_device_attr 'Current_Pending_Sector|Runtime_Bad_Block' R"	# It is for the Current Pending Sector count of this device.
+		FTABLE[12]="send_device_attr 'Offline_Uncorrectable|Uncorrectable_Error' R" 		# It is for the Off-line Uncorrectable count of this device.
+		FTABLE[13]="send_device_attr 'CRC_Error_Count' R" 		# It is for the UDMA CRC Error count of this device.
 		FTABLE[14]="send_device_attr 'Read_Error_Rate' L" 			# It is for the Read Error Rate (lifetime) of this device.
 		FTABLE[15]="send_device_attr 'Seek_Error_Rate' L"	 		# It is for the Seek Error Rate (lifetime) of this device.
-		FTABLE[16]="send_device_attr 'Hardware_ECC_Recovered' L" 	# It is for the Hardware ECC recovered (lifetime) of this device.
+		FTABLE[16]="send_device_attr 'Hardware_ECC_Recovered|ECC_Error_Rate' L" 	# It is for the Hardware ECC recovered (lifetime) of this device.
 		FTABLE[17]="send_device_info 'Firmware Version:'" 			# It is for the Firmware Version installed on this device.
-		FTABLE[18]="send_device_attr 'SSD_Life_Left' L" 			# It is for the SSD Life Left of this device.
+		FTABLE[18]="send_device_attr 'SSD_Life|Wear_Leveling' L" 			# It is for the SSD Life Left of this device.
 		FTABLE[19]="send_device_attr 'Power_Cycle_Count' R" 			# It is for the Power Cycle Count of this device.
 		FTABLE[20]="send_device_attr 'Power_On_Hours' R" 			# It is for the Power On Hours of this device.
 


### PR DESCRIPTION
Two changes here:

1) If a grep were to return two matches, such as "ATA Version is:", it will cause SNMP getnext to fail.
Here is my hardware info as an example:

**cat /tmp/snmp-cache/smartctl/dev_sda_info**
smartctl 7.0 2018-12-30 r4883 [x86_64-linux-5.4.45-esos.prod] (local build)
Copyright (C) 2002-18, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Samsung based SSDs
Device Model:     Samsung SSD 850 PRO 256GB
Serial Number:    S39KNX0J744200J
LU WWN Device Id: 5 002538 d4219b347
Firmware Version: EXM04B6Q
User Capacity:    256,060,514,304 bytes [256 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
Device is:        In smartctl database [for details use: -P show]
**ATA Version is:   ACS-2, ATA8-ACS T13/1699-D revision 4c**  <-- This line matches "ATA Version is:"
**SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)**       <-- And this line also matches
Local Time is:    Fri Jul 10 07:15:01 2020 -00
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

This causes a linefeed in the VALUE variable, which is interpreted as sending two responses, causing the next SNMP command in the_loop to fail.

To fix this I added "-m 1" as a grep argument so it only pulls the first match.

2) A lot of HD manufacturers use different names for their SMART attributes, so I included a few of the common ones I've seen. I noticed there was a new function to handle the temperature attribute, as it had two names. So to make it a bit more efficient, I modified the regex with -E so that it can use regex pipes | to match different values, and added a few alternative attributes names in the FTABLE array.